### PR TITLE
Add optional "channel" argument to event-source

### DIFF
--- a/src/ninjudd/eventual/client.cljs
+++ b/src/ninjudd/eventual/client.cljs
@@ -7,10 +7,10 @@
       (vary-meta merge {:event-id (.-lastEventId event)
                         :event-type (keyword (.-type event))})))
 
-(defn event-source [f url & [event-types]]
+(defn event-source [f url & [event-types channel]]
   (let [event-types (or event-types [:message])
         source (new js/EventSource url)
-        channel (async/chan)]
+        channel (or channel (async/chan))]
     (doseq [event-type event-types]
       (.addEventListener source (name event-type)
                          (fn [event]
@@ -22,11 +22,11 @@
     {:event-source source
      :channel channel}))
 
-(defn edn-event-source [url & [event-types]]
-  (event-source read-string url event-types))
+(defn edn-event-source [url & [event-types channel]]
+  (event-source read-string url event-types channel))
 
-(defn json-event-source [url & [event-types]]
-  (event-source #(.parse js/JSON %) url event-types))
+(defn json-event-source [url & [event-types channel]]
+  (event-source #(.parse js/JSON %) url event-types channel))
 
 (defn close-event-source! [{:keys [channel event-source]}]
   (when event-source


### PR DESCRIPTION
I have a need for this - I wanted to use a transducer on the event source's channel.

As far as the changes, multiple optional positional args are less than ideal, but I ran with it.
